### PR TITLE
Change gender input to select

### DIFF
--- a/juen-project/src/App.js
+++ b/juen-project/src/App.js
@@ -55,13 +55,13 @@ function App() {
             />
 
             <label>Gender:</label>
-            <input
-              type="text"
-              placeholder="Resident Gender"
-              value={gender}
+            <select 
               onChange={(e) => setGender(e.target.value)}
               style={{ width: '100%', marginBottom: '10px' }}
-            />
+            >
+              <option value="Male">Male</option>
+              <option value="Female">Female</option>
+            </select>
 
             <label>Room/Bed Number:</label>
             <input


### PR DESCRIPTION
For gender, it would be better to use a `select` input instead of `text` since you'll want to have a specific list of options available.

Other things to consider (for @Juen-Yang):
* create a `Select` component that can be reusable?
* what if the option value and label are different? e.g. value=M, label should read `Male`